### PR TITLE
Fix 404 on images list route

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,12 +5,6 @@ const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
-app.use(express.static(__dirname));
-
-app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, 'index.html'));
-});
-
 app.get('/images-list', (req, res) => {
   const dir = path.join(__dirname, 'images');
   fs.readdir(dir, (err, files) => {
@@ -20,6 +14,12 @@ app.get('/images-list', (req, res) => {
     const imageFiles = files.filter(file => /\.(jpe?g|png|gif|bmp|webp|heic)$/i.test(file));
     res.json(imageFiles);
   });
+});
+
+app.use(express.static(__dirname));
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- move `/images-list` route before static middleware so it's reachable

## Testing
- `node --check server.js`
