### PR TITLE
Fix image load fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Gallery
 
-A simple gallery that displays all images located in the `images` directory.
+A simple gallery that displays images from the local `images` directory. If the
+`/images-list` route is unavailable (for example when the page is opened
+directly from a file instead of via the Node server) the gallery falls back to
+predefined remote URLs.
 
 ## Running locally
 

--- a/script.js
+++ b/script.js
@@ -1,30 +1,49 @@
 document.addEventListener('DOMContentLoaded', () => {
     const gallery = document.querySelector('.gallery');
 
-    // Manually specified image URLs while automatic loading is disabled
-    const imageUrls = [
+    // fallback image URLs used when the server is unavailable
+    const fallbackUrls = [
         'https://raw.githubusercontent.com/Kulimar/test/main/images/20250511_094432.jpg',
         'https://raw.githubusercontent.com/Kulimar/test/main/images/IMG_3543.HEIC',
         'https://raw.githubusercontent.com/Kulimar/test/main/images/IMG_3587.HEIC',
         'https://raw.githubusercontent.com/Kulimar/test/main/images/IMG_3591.HEIC'
     ];
 
-    imageUrls.forEach((url, index) => {
-        const photo = document.createElement('div');
-        photo.classList.add('photo', 'fade-in');
-        photo.style.animationDelay = `${index * 0.2}s`;
+    const renderImages = (urls) => {
+        urls.forEach((url, index) => {
+            const photo = document.createElement('div');
+            photo.classList.add('photo', 'fade-in');
+            photo.style.animationDelay = `${index * 0.2}s`;
 
-        const img = document.createElement('img');
-        img.src = url;
-        img.alt = url.split('/').pop();
+            const img = document.createElement('img');
+            img.src = url;
+            img.alt = url.split('/').pop();
 
-        photo.appendChild(img);
-        gallery.appendChild(photo);
+            photo.appendChild(img);
+            gallery.appendChild(photo);
 
-        photo.addEventListener('click', () => {
-            photo.classList.toggle('expanded');
+            photo.addEventListener('click', () => {
+                photo.classList.toggle('expanded');
+            });
         });
-    });
+    };
+
+    // try loading image list from the local server; fall back to predefined URLs
+    fetch('/images-list')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`Server responded with ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(files => {
+            const urls = files.map(f => `/images/${f}`);
+            renderImages(urls);
+        })
+        .catch(err => {
+            console.error('Error loading images:', err);
+            renderImages(fallbackUrls);
+        });
 
     const toggleButton = document.getElementById('theme-toggle');
     const toggleIcon = document.getElementById('theme-icon');


### PR DESCRIPTION
## Summary
- load image list from `/images-list` if available
- fall back to predefined URLs on failure
- document fallback behaviour in README

## Testing
- `npm test` *(fails: Missing script 'test')*