### PR TITLE
Fix missing heart icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lego & Minecraft Creations</title>
     <link rel="stylesheet" href="styles.css">
-    <script src="https://unpkg.com/lucide@latest" defer></script>
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js" defer></script>
 </head>
 <body>
     <button id="theme-toggle" aria-label="Toggle color mode">

--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     btn.setAttribute('aria-pressed', isLiked);
                     btn.classList.toggle('liked', isLiked);
                 });
-                lucide.createIcons();
+                if (window.lucide) lucide.createIcons();
             })
             .catch(err => console.error('Error loading likes:', err));
     };
@@ -119,8 +119,8 @@ document.addEventListener('DOMContentLoaded', () => {
         document.body.classList.toggle('dark');
         const isDark = document.body.classList.contains('dark');
         toggleIcon.setAttribute('data-lucide', isDark ? 'sun' : 'moon');
-        lucide.createIcons();
+        if (window.lucide) lucide.createIcons();
     });
 
-    lucide.createIcons();
+    if (window.lucide) lucide.createIcons();
 });


### PR DESCRIPTION
## Summary
- load lucide from the UMD bundle so icons initialize correctly
- guard calls to `lucide.createIcons()` when library is unavailable

## Testing
- `npm test` *(fails: Missing script: "test")*