### PR TITLE
Fix likes API URL

### DIFF
--- a/functions/likes.js
+++ b/functions/likes.js
@@ -19,7 +19,10 @@ async function writeDb(db) {
 
 exports.handler = async (event) => {
   const method = event.httpMethod;
-  const headers = { 'Content-Type': 'application/json' };
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  };
   const parseCookies = (str) => Object.fromEntries(str.split(';').map(c => c.trim().split('=').map(decodeURIComponent)).filter(p => p[0]));
   const serializeCookie = (name, val, opts = {}) => {
     const pairs = [`${name}=${encodeURIComponent(val)}`];

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     const gallery = document.querySelector('.gallery');
-    const apiBase = '/api';   // keep if you have a proxy; otherwise absolute URL
+    const apiBase =
+      'https://kulimar-gallery.netlify.app/.netlify/functions'; // full Netlify functions URL
     const likeEndpoint = `${apiBase}/likes`;
 
     const fetchLikes = (ids) => {


### PR DESCRIPTION
## Summary
- call Netlify functions directly from the client
- enable CORS for the likes function

## Testing
- `node -e "require('./functions/likes.js')"`