### PR TITLE
Add ambient audio playback on image load or hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <div id="loading-container" class="loading-container hidden">
         <div id="loading-bar"></div>
     </div>
+    <audio id="bg-music" src="audio/eMastered_WooSong.mp3" preload="auto"></audio>
     <h1>Lego & Minecraft Gallery</h1>
     <div class="gallery"></div>
 


### PR DESCRIPTION
## Summary
- embed eMastered_WooSong.mp3 audio in the page
- play audio once an image loads or is hovered for the first time
- fade volume in slowly and fade out near the end

## Testing
- `npm test` *(fails: Missing script)*